### PR TITLE
Consider body size only in requests which use body

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -41,7 +41,7 @@ class StreamHandler
 
             // Append a content-length header if body size is zero to match
             // cURL's behavior.
-            if (0 === $request->getBody()->getSize()) {
+            if ($request->getMethod() !== 'GET' && 0 === $request->getBody()->getSize()) {
                 $request = $request->withHeader('Content-Length', '0');
             }
 


### PR DESCRIPTION
GET requests do not use body, therefore it does not make sense to check their body size.

The reason for this fix is a strange problem we encountered recently, where a server misinterpreted Content-Length: 0 of a GET request presumably with Content-Range, so it did not send any data. This fix solved the issue for us.